### PR TITLE
Add support for JSON_VALUE() found in MariaDb

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ This library provide set of DQL functions.
 * [JSON_VALID(val)](https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid)
 	- Returns 0 or 1 to indicate whether a value is a valid JSON document.
 
+### MariaDb 10.2.3 JSON operators
+* [JSON_VALUE(json_doc, path)](https://mariadb.com/kb/en/library/json_value/)
+	- Returns the scalar specified by the path. Returns NULL if there is no match.
+
 ### PostgreSQL 9.3+ JSON operators
 Basic support for JSON operators is implemented. This works even with `Doctrine\DBAL` v2.5. [Official documentation of JSON operators](https://www.postgresql.org/docs/9.3/static/functions-json.html).
 

--- a/src/Query/AST/Functions/Mariadb/JsonValue.php
+++ b/src/Query/AST/Functions/Mariadb/JsonValue.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Syslogic\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * "JSON_VALUE" "(" StringPrimary "," StringPrimary ")"
+ */
+class JsonValue extends FunctionNode
+{
+	const FUNCTION_NAME = 'JSON_VALUE';
+
+	/**
+	 * @var \Doctrine\ORM\Query\AST\Node
+	 */
+	public $jsonDocExpr;
+
+	/**
+	 * @var \Doctrine\ORM\Query\AST\Node
+	 */
+	public $jsonPathExpr;
+
+	/**
+	 * @param SqlWalker $sqlWalker
+	 * @return string
+	 * @throws DBALException
+	 */
+	public function getSql(SqlWalker $sqlWalker)
+	{
+		$jsonDoc = $sqlWalker->walkStringPrimary($this->jsonDocExpr);
+		$jsonPath = $sqlWalker->walkStringPrimary($this->jsonPathExpr);
+
+		if ($sqlWalker->getConnection()->getDatabasePlatform() instanceof MySqlPlatform) {
+			return sprintf('%s(%s, %s)', static::FUNCTION_NAME, $jsonDoc, $jsonPath);
+		}
+
+		throw DBALException::notSupported(static::FUNCTION_NAME);
+	}
+
+	/**
+	 * @param Parser $parser
+	 * @throws \Doctrine\ORM\Query\QueryException
+	 */
+	public function parse(Parser $parser)
+	{
+		$parser->match(Lexer::T_IDENTIFIER);
+		$parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+		$this->jsonDocExpr = $parser->StringPrimary();
+
+		$parser->match(Lexer::T_COMMA);
+
+		$this->jsonPathExpr = $parser->StringPrimary();
+
+		$parser->match(Lexer::T_CLOSE_PARENTHESIS);
+	}
+
+}


### PR DESCRIPTION
Using JSON_VALUE, you don't need to quote the value. I put the function under "Mariadb" folder even though it looks for MysqlPlatform. Latest Doctrine has MariaDb1027Platform but that extends MysqlPlatform.

```php
$queryBuilder
  ->select('c')
  ->from('Customer', 'c')
  ->where("JSON_VALUE(c.attributes, '$.certificates') = :certificates");
 
$result = $q->execute(array(
  'certificates' => 'BIO',
));
```