### PR TITLE
Adding JSON_EXISTS for MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A set of extensions to Doctrine 2 that add support for json query functions.
 |:--:|:---------:|
 | MySQL | `JSON_APPEND, JSON_ARRAY, JSON_ARRAY_APPEND, JSON_ARRAY_INSERT, JSON_CONTAINS, JSON_CONTAINS_PATH, JSON_DEPTH, JSON_EXTRACT, JSON_INSERT, JSON_KEYS, JSON_LENGTH, JSON_MERGE, JSON_OBJECT, JSON_QUOTE, JSON_REMOVE, JSON_REPLACE, JSON_SEARCH, JSON_SET, JSON_TYPE, JSON_UNQUOTE, JSON_VALID` |
 | PostgreSQL | `JSON_EXTRACT_PATH, GT, GT_GT, SHARP_GT, SHARP_GT_GT` |
-| MariaDb | `JSON_VALUE` |
+| MariaDb | `JSON_VALUE, JSON_EXISTS` |
 
 Table of Contents
 -----------------
@@ -84,6 +84,8 @@ This library provide set of DQL functions.
 ### MariaDb 10.2.3 JSON operators
 * [JSON_VALUE(json_doc, path)](https://mariadb.com/kb/en/library/json_value/)
 	- Returns the scalar specified by the path. Returns NULL if there is no match.
+* [JSON_EXISTS(json_doc, path)](https://mariadb.com/kb/en/library/json_exists/)
+    - Determines whether a specified JSON value exists in the given data. Returns 1 if found, 0 if not, or NULL if any of the inputs were NULL.
 
 ### PostgreSQL 9.3+ JSON operators
 Basic support for JSON operators is implemented. This works even with `Doctrine\DBAL` v2.5. [Official documentation of JSON operators](https://www.postgresql.org/docs/9.3/static/functions-json.html).

--- a/src/Query/AST/Functions/Mariadb/JsonExists.php
+++ b/src/Query/AST/Functions/Mariadb/JsonExists.php
@@ -8,12 +8,63 @@ use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
-use Syslogic\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonKeys;
 
 /**
  * "JSON_EXISTS" "(" StringPrimary "," StringPrimary  ")"
  */
-class JsonExists extends JsonKeys
+class JsonExists extends FunctionNode
 {
-	const FUNCTION_NAME = 'JSON_EXISTS';
+    const FUNCTION_NAME = 'JSON_EXISTS';
+
+    /**
+     * @var \Doctrine\ORM\Query\AST\Node
+     */
+    public $jsonDocExpr;
+
+    /**
+     * @var \Doctrine\ORM\Query\AST\Node
+     */
+    public $jsonPathExpr;
+
+    /**
+     * @param SqlWalker $sqlWalker
+     * @return string
+     * @throws DBALException
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $jsonDocExpr = $sqlWalker->walkStringPrimary($this->jsonDocExpr);
+
+        $jsonPath = '';
+        if (!empty($this->jsonPathExpr)) {
+            $jsonPath = ', ' . $sqlWalker->walkStringPrimary($this->jsonPathExpr);
+        }
+
+        if ($sqlWalker->getConnection()->getDatabasePlatform() instanceof MySqlPlatform)
+        {
+            return sprintf('%s(%s)', static::FUNCTION_NAME, $jsonDocExpr . $jsonPath);
+        }
+
+        throw DBALException::notSupported(static::FUNCTION_NAME);
+    }
+
+    /**
+     * @param Parser $parser
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->jsonDocExpr = $parser->StringPrimary();
+
+        if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
+            $parser->match(Lexer::T_COMMA);
+            $this->jsonPathExpr = $parser->StringPrimary();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
 }

--- a/src/Query/AST/Functions/Mariadb/JsonExists.php
+++ b/src/Query/AST/Functions/Mariadb/JsonExists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Syslogic\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Syslogic\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonKeys;
+
+/**
+ * "JSON_EXISTS" "(" StringPrimary "," StringPrimary  ")"
+ */
+class JsonExists extends JsonKeys
+{
+	const FUNCTION_NAME = 'JSON_EXISTS';
+}


### PR DESCRIPTION
This is my first QDL, hopefully I'm not breaking anything :)

Here is an example how it works:
`
$queryBuilder
  ->select('c')
  ->from('Customer', 'c')
  ->where("JSON_EXISTS(c.attributes, '$.certificates') = 1");
 
$result = $q->execute();
`